### PR TITLE
feat: Refactor EventRouter to use RouteProvider

### DIFF
--- a/apps/public-web/src/app.ts
+++ b/apps/public-web/src/app.ts
@@ -1,23 +1,22 @@
 import {
   EventRelayProcessor,
+  EventRouter,
   HttpDispatcher,
   HttpGateway,
   HttpProcessor,
-  SingleUseRouter,
   pingRequestHandler,
 } from '@sektek/common';
 import { Router as ExpressRouter } from 'express';
 
 export const app = ExpressRouter();
 
-const router = new SingleUseRouter({
-  name: 'EventRelayRouter',
-  routeDecider: async event => event.id,
-});
-
 const eventRelayProcessor = new EventRelayProcessor({
   handler: new HttpDispatcher({ url: 'http://dispatcher:3000/' }),
-  router,
+});
+
+const router = new EventRouter({
+  name: 'EventRelayRouter',
+  routeProvider: eventRelayProcessor,
 });
 
 const httpProcessor = new HttpProcessor({

--- a/libs/common/src/event-channel.ts
+++ b/libs/common/src/event-channel.ts
@@ -17,8 +17,10 @@ export const isEventChannel = (obj: unknown): obj is EventChannel<Event> =>
   !isPrimitive(obj) &&
   (obj as EventChannel<Event>).send instanceof Function;
 
-export class NullChannel {
+export class NullChannel<T extends Event> implements EventChannel<T> {
   static send(): Promise<void> {
     return Promise.resolve();
   }
+
+  send = NullChannel.send;
 }

--- a/libs/common/src/event-relay-processor.ts
+++ b/libs/common/src/event-relay-processor.ts
@@ -55,6 +55,6 @@ export class EventRelayProcessor<T extends Event, R extends Event>
       this.#channelMap.delete(route);
     }
 
-    return channel?.send ?? this.#defaultChannel.send;
+    return channel?.send?.bind(channel) ?? this.#defaultChannel.send;
   }
 }

--- a/libs/common/src/event-router.ts
+++ b/libs/common/src/event-router.ts
@@ -39,7 +39,8 @@ export type RouteProviderFn<T extends Event> = (
   event: T,
 ) => Promise<EventChannelFn<T>>;
 
-const DEFAULT_ROUTE_PROVIDER: RouteProviderFn<Event> = async () => NullChannel.send;
+const DEFAULT_ROUTE_PROVIDER: RouteProviderFn<Event> = async () =>
+  NullChannel.send;
 
 export interface RouteProvider<T extends Event> {
   get: RouteProviderFn<T>;
@@ -121,7 +122,8 @@ export class EventRouter<T extends Event>
     this.routeProvider =
       options.routeProvider instanceof Function
         ? options.routeProvider
-        : options.routeProvider?.get ?? DEFAULT_ROUTE_PROVIDER;
+        : options.routeProvider?.get?.bind(options.routeProvider) ??
+          DEFAULT_ROUTE_PROVIDER;
   }
 
   async send(event: T): Promise<void> {


### PR DESCRIPTION
This updates the `EventRouter` to no longer be responsible for storing and managing the routes it will deliver events to

Instead it will delegate this reponsibility to a `RouteProvider` which when provided with an event will return the appropriate `EventChannelFn` to deliver the `Event` to. 

The `EventRelayProcessor` has been modified to act as a `RouteProvider` changing the expectation that it receives the Router it will be storing routes to and instead being provided to a router to act as the RouteProvider.

This change will come into play further when adding a RouteProvider that can store data to a shared data source such as Redis and will be responsible for creating an EventChannel based on this data.